### PR TITLE
Highest protocol version for pickle.dump to improve performance

### DIFF
--- a/mecha/api.py
+++ b/mecha/api.py
@@ -85,7 +85,7 @@ class AstCacheBackend:
         """Dump the pickled data."""
         data["mecha"] = self.version
         data["python"] = sys.version
-        pickle.dump(data, f)
+        pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     def load(self, f: BufferedReader) -> AstRoot:
         """Load the ast."""


### PR DESCRIPTION
This should speed up the reading and writing of ast cache files a bit