### PR TITLE
feat: add return run nested root syntax.

### DIFF
--- a/examples/basic_nesting/src/data/demo/functions/foo.mcfunction
+++ b/examples/basic_nesting/src/data/demo/functions/foo.mcfunction
@@ -202,3 +202,13 @@ function demo:ret2:
     execute if score some score matches 0 run return run function demo:ret2/cond:
         say hi
         return 0
+
+
+return run say inline by default
+return run function demo:named_return_run:
+    say named function
+return run:
+    say inlined command
+return run:
+    say anonymous function 1
+    say anonymous function 2

--- a/examples/basic_nesting/src/data/demo/functions/foo.mcfunction
+++ b/examples/basic_nesting/src/data/demo/functions/foo.mcfunction
@@ -207,8 +207,8 @@ function demo:ret2:
 return run say inline by default
 return run function demo:named_return_run:
     say named function
-return run:
+return:
     say inlined command
-return run:
+return:
     say anonymous function 1
     say anonymous function 2

--- a/mecha/contrib/nesting.py
+++ b/mecha/contrib/nesting.py
@@ -166,7 +166,7 @@ class NestedCommandsTransformer(MutatingReducer):
         return node
 
     @rule(AstCommand, identifier="execute:commands")
-    @rule(AstCommand, identifier="return:run:commands")
+    @rule(AstCommand, identifier="return:commands")
     def nesting_execute_commands(self, node: AstCommand):
         root = cast(AstRoot, node.arguments[0])
 

--- a/mecha/contrib/nesting.py
+++ b/mecha/contrib/nesting.py
@@ -1,6 +1,5 @@
 """Plugin for handling nested commands."""
 
-
 __all__ = [
     "NestedCommandsTransformer",
     "NestingOptions",
@@ -40,6 +39,7 @@ from mecha.contrib.nested_location import NestedLocationResolver
 class NestingOptions(BaseModel):
     generate_execute: str = "nested_execute_{incr}"
     generate_macro: str = "nested_macro_{incr}"
+    generate_return: str = "nested_return_{incr}"
 
 
 def beet_default(ctx: Context):
@@ -64,6 +64,7 @@ def nesting(ctx: Context, opts: NestingOptions):
             database=mc.database,
             generate_execute_template=opts.generate_execute,
             generate_macro_template=opts.generate_macro,
+            generate_return_template=opts.generate_return,
             nested_location_resolver=ctx.inject(NestedLocationResolver),
         )
     )
@@ -82,9 +83,12 @@ def parse_nested_root(stream: TokenStream) -> AstRoot:
 
     commands: List[AstCommand] = []
 
-    with stream.intercept("newline"), stream.provide(
-        scope=(),
-        line_indentation=command_level,
+    with (
+        stream.intercept("newline"),
+        stream.provide(
+            scope=(),
+            line_indentation=command_level,
+        ),
     ):
         while True:
             commands.append(delegate("root_item", stream))
@@ -110,6 +114,7 @@ class NestedCommandsTransformer(MutatingReducer):
     database: CompilationDatabase = required_field()
     generate_execute_template: str = required_field()
     generate_macro_template: str = required_field()
+    generate_return_template: str = required_field()
     nested_location_resolver: NestedLocationResolver = required_field()
 
     identifier_map: dict[str, str] = field(
@@ -161,8 +166,16 @@ class NestedCommandsTransformer(MutatingReducer):
         return node
 
     @rule(AstCommand, identifier="execute:commands")
+    @rule(AstCommand, identifier="return:run:commands")
     def nesting_execute_commands(self, node: AstCommand):
         root = cast(AstRoot, node.arguments[0])
+
+        if node.identifier == "execute:commands":
+            generate_template = self.generate_execute_template
+            identifier = "execute:run:subcommand"
+        else:
+            generate_template = self.generate_return_template
+            identifier = "return:run:subcommand"
 
         single_command = None
         for command in root.commands:
@@ -177,14 +190,15 @@ class NestedCommandsTransformer(MutatingReducer):
         if single_command:
             subcommand = single_command
 
-            if subcommand.identifier == "execute:subcommand":
+            if (
+                node.identifier == "execute:commands"
+                and subcommand.identifier == "execute:subcommand"
+            ):
                 return subcommand.arguments[0]
 
         else:
             namespace, resolved = self.nested_location_resolver.resolve()
-            path = self.generate.format(
-                f"{namespace}:{resolved}/{self.generate_execute_template}"
-            )
+            path = self.generate.format(f"{namespace}:{resolved}/{generate_template}")
 
             self.emit_function(path, root)
 
@@ -194,7 +208,7 @@ class NestedCommandsTransformer(MutatingReducer):
             )
 
         return AstCommand(
-            identifier="execute:run:subcommand",
+            identifier=identifier,
             arguments=AstChildren([subcommand]),
         )
 

--- a/mecha/resources/nesting.json
+++ b/mecha/resources/nesting.json
@@ -255,15 +255,10 @@
     "return": {
       "type": "literal",
       "children": {
-        "run": {
-          "type": "literal",
-          "children": {
-            "commands": {
-              "type": "argument",
-              "parser": "mecha:nested_root",
-              "executable": true
-            }
-          }
+        "commands": {
+          "type": "argument",
+          "parser": "mecha:nested_root",
+          "executable": true
         }
       }
     }

--- a/mecha/resources/nesting.json
+++ b/mecha/resources/nesting.json
@@ -251,6 +251,21 @@
           }
         }
       }
+    },
+    "return": {
+      "type": "literal",
+      "children": {
+        "run": {
+          "type": "literal",
+          "children": {
+            "commands": {
+              "type": "argument",
+              "parser": "mecha:nested_root",
+              "executable": true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/tests/snapshots/examples__build_basic_nesting__0.pack.md
+++ b/tests/snapshots/examples__build_basic_nesting__0.pack.md
@@ -68,6 +68,10 @@ function demo:foo/nested_macro_4 with block ~ ~ ~
 function demo:foo/nested_macro_5 with block ~ ~ ~ Items
 function demo:foo/nested_macro_6 with storage demo:temp
 function demo:foo/nested_macro_7 with storage demo:temp args
+return run say inline by default
+return run function demo:named_return_run
+return run say inlined command
+return run function demo:foo/nested_return_0
 ```
 
 `@function demo:wat`
@@ -265,6 +269,19 @@ return 0
 ```mcfunction
 say hi
 return 0
+```
+
+`@function demo:named_return_run`
+
+```mcfunction
+say named function
+```
+
+`@function demo:foo/nested_return_0`
+
+```mcfunction
+say anonymous function 1
+say anonymous function 2
 ```
 
 `@function demo:thing1`


### PR DESCRIPTION
Adds nested root syntax for `return run` similar to `execute run`.

```py
return run:
    say inline

return run:
    ...
```