### PR TITLE
feat: add item predicate syntax and inline loot arguments

### DIFF
--- a/mecha/ast.py
+++ b/mecha/ast.py
@@ -928,7 +928,9 @@ class AstItem(AstNode):
     """Ast item node."""
 
     identifier: Optional[AstResourceLocation] = None
-    components: AstChildren[Union[AstItemComponent, AstItemComponentGroup]] = AstChildren()
+    components: AstChildren[Union[AstItemComponent, AstItemComponentGroup]] = (
+        AstChildren()
+    )
     data_tags: Optional[AstNbtCompound] = None
 
 

--- a/mecha/ast.py
+++ b/mecha/ast.py
@@ -56,6 +56,9 @@ __all__ = [
     "AstBlock",
     "AstItemComponent",
     "AstItem",
+    "AstItemTest",
+    "AstItemTestGroup",
+    "AstItemPredicate",
     "AstItemSlot",
     "AstItemSlots",
     "AstRange",
@@ -919,6 +922,32 @@ class AstItem(AstNode):
 
     identifier: AstResourceLocation = required_field()
     components: AstChildren[AstItemComponent] = AstChildren()
+    data_tags: Optional[AstNbtCompound] = None
+
+
+@dataclass(frozen=True, slots=True)
+class AstItemTest(AstNode):
+    """Ast item test node."""
+
+    inverted: bool = False
+    predicate: bool = False
+    key: AstResourceLocation = required_field()
+    value: Optional[AstNbt] = None
+
+
+@dataclass(frozen=True, slots=True)
+class AstItemTestGroup(AstNode):
+    """Ast item test group node."""
+
+    all_of_tests: AstChildren[AstItemTest] = AstChildren()
+
+
+@dataclass(frozen=True, slots=True)
+class AstItemPredicate(AstNode):
+    """Ast item predicate node."""
+
+    identifier: Union[AstResourceLocation, AstWildcard] = required_field()
+    any_of_tests: AstChildren[AstItemTestGroup] = AstChildren()
     data_tags: Optional[AstNbtCompound] = None
 
 

--- a/mecha/ast.py
+++ b/mecha/ast.py
@@ -55,10 +55,8 @@ __all__ = [
     "AstBlockState",
     "AstBlock",
     "AstItemComponent",
+    "AstItemComponentGroup",
     "AstItem",
-    "AstItemTest",
-    "AstItemTestGroup",
-    "AstItemPredicate",
     "AstItemSlot",
     "AstItemSlots",
     "AstRange",
@@ -912,23 +910,6 @@ class AstBlock(AstNode):
 class AstItemComponent(AstNode):
     """Ast item component node."""
 
-    key: AstResourceLocation = required_field()
-    value: AstNbt = required_field()
-
-
-@dataclass(frozen=True, slots=True)
-class AstItem(AstNode):
-    """Ast item node."""
-
-    identifier: AstResourceLocation = required_field()
-    components: AstChildren[AstItemComponent] = AstChildren()
-    data_tags: Optional[AstNbtCompound] = None
-
-
-@dataclass(frozen=True, slots=True)
-class AstItemTest(AstNode):
-    """Ast item test node."""
-
     inverted: bool = False
     predicate: bool = False
     key: AstResourceLocation = required_field()
@@ -936,18 +917,18 @@ class AstItemTest(AstNode):
 
 
 @dataclass(frozen=True, slots=True)
-class AstItemTestGroup(AstNode):
-    """Ast item test group node."""
+class AstItemComponentGroup(AstNode):
+    """Ast item component group node."""
 
-    all_of_tests: AstChildren[AstItemTest] = AstChildren()
+    components: AstChildren[AstItemComponent] = AstChildren()
 
 
 @dataclass(frozen=True, slots=True)
-class AstItemPredicate(AstNode):
-    """Ast item predicate node."""
+class AstItem(AstNode):
+    """Ast item node."""
 
-    identifier: Union[AstResourceLocation, AstWildcard] = required_field()
-    any_of_tests: AstChildren[AstItemTestGroup] = AstChildren()
+    identifier: Optional[AstResourceLocation] = None
+    components: AstChildren[Union[AstItemComponent, AstItemComponentGroup]] = AstChildren()
     data_tags: Optional[AstNbtCompound] = None
 
 

--- a/mecha/parse.py
+++ b/mecha/parse.py
@@ -229,6 +229,12 @@ def get_default_parsers() -> Dict[str, Parser]:
         "integer_range": IntegerRangeConstraint(delegate("range")),
         "resource_location_or_tag": CommentDisambiguation(ResourceLocationParser()),
         "resource_location": NoTagConstraint(delegate("resource_location_or_tag")),
+        "resource_location_or_nbt": AlternativeParser(
+            [
+                delegate("resource_location"),
+                MultilineParser(delegate("nbt_compound")),
+            ]
+        ),
         "uuid": parse_uuid,
         "objective": BasicLiteralParser(AstObjective),
         "objective_criteria": BasicLiteralParser(AstObjectiveCriteria),
@@ -471,9 +477,9 @@ def get_default_parsers() -> Dict[str, Parser]:
         "command:argument:minecraft:template_mirror": delegate("template_mirror"),
         "command:argument:minecraft:float_range": delegate("range"),
         "command:argument:minecraft:function": delegate("resource_location_or_tag"),
-        "command:argument:minecraft:loot_table": delegate("resource_location"),
-        "command:argument:minecraft:loot_predicate": delegate("resource_location"),
-        "command:argument:minecraft:loot_modifier": delegate("resource_location"),
+        "command:argument:minecraft:loot_table": delegate("resource_location_or_nbt"),
+        "command:argument:minecraft:loot_predicate": delegate("resource_location_or_nbt"),
+        "command:argument:minecraft:loot_modifier": delegate("resource_location_or_nbt"),
         "command:argument:minecraft:game_profile": delegate("game_profile"),
         "command:argument:minecraft:gamemode": delegate("gamemode"),
         "command:argument:minecraft:heightmap": delegate("heightmap"),

--- a/mecha/serialize.py
+++ b/mecha/serialize.py
@@ -280,7 +280,7 @@ class Serializer(Visitor):
         yield node.identifier
         if node.components:
             result.append("[")
-            if len(node.components) > 0 and isinstance(node.components[0], AstItemComponentGroup):
+            if isinstance(node.components[0], AstItemComponentGroup):
                 pipe = "|" if self.formatting.cmd_compact else " | "
             else:
                 pipe = "," if self.formatting.cmd_compact else ", "

--- a/mecha/serialize.py
+++ b/mecha/serialize.py
@@ -277,7 +277,10 @@ class Serializer(Visitor):
 
     @rule(AstItem)
     def item(self, node: AstItem, result: List[str]):
-        yield node.identifier
+        if node.identifier:
+            yield node.identifier
+        else:
+            result.append("*")
         if node.components:
             result.append("[")
             if isinstance(node.components[0], AstItemComponentGroup):

--- a/tests/snapshots/parse__command_examples__0.txt
+++ b/tests/snapshots/parse__command_examples__0.txt
@@ -7315,6 +7315,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8626, lineno=212, colno=24)
               end_location: SourceLocation(pos=8635, lineno=212, colno=33)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8626, lineno=212, colno=24)
@@ -7353,6 +7355,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8660, lineno=213, colno=24)
               end_location: SourceLocation(pos=8669, lineno=213, colno=33)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8660, lineno=213, colno=24)
@@ -7408,6 +7412,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8703, lineno=214, colno=23)
               end_location: SourceLocation(pos=8711, lineno=214, colno=31)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8703, lineno=214, colno=23)
@@ -7423,6 +7429,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8712, lineno=214, colno=32)
               end_location: SourceLocation(pos=8725, lineno=214, colno=45)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8712, lineno=214, colno=32)
@@ -7502,6 +7510,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8766, lineno=216, colno=15)
               end_location: SourceLocation(pos=8789, lineno=216, colno=38)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8766, lineno=216, colno=15)
@@ -7553,6 +7563,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8816, lineno=217, colno=26)
               end_location: SourceLocation(pos=8824, lineno=217, colno=34)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8816, lineno=217, colno=26)
@@ -7591,6 +7603,8 @@
             <class 'mecha.ast.AstItemComponent'>
               location: SourceLocation(pos=8848, lineno=218, colno=23)
               end_location: SourceLocation(pos=8879, lineno=218, colno=54)
+              inverted: False
+              predicate: False
               key:
                 <class 'mecha.ast.AstResourceLocation'>
                   location: SourceLocation(pos=8848, lineno=218, colno=23)


### PR DESCRIPTION
This PR adds support for the new item predicate syntax.
```
*[custom_data~{gm4_metallurgy:{stored_shamir:"lumos"}},damage|!max_item_stack=1]
```

I would like some feedback, mostly on the AST structure and maybe on the parser (could it be split up, does it need anything special to support multiline?)

Also the tests are failing, probably because I changed the AST result of the `item_predicate` format, it's no longer an `AstItem`, but now an `AstItemPredicate`. Would it be better to have a single AST that supports both?