### PR TITLE
fix: add saddle item slot

### DIFF
--- a/mecha/ast.py
+++ b/mecha/ast.py
@@ -988,6 +988,7 @@ class AstItemSlot(AstOption):
             "armor.head",
             "armor.legs",
             "contents",
+            "saddle",
             "weapon",
             "weapon.mainhand",
             "weapon.offhand",


### PR DESCRIPTION
The `horse.saddle` slot was renamed to `saddle` in 1.21.5